### PR TITLE
Added streamToStream() and use it in download

### DIFF
--- a/src/api/StreamUtils.ts
+++ b/src/api/StreamUtils.ts
@@ -10,7 +10,7 @@
  */
 
 import { IHandlerResponseApi, ITaskWithStatus, TaskStage, TextUtils } from "@brightside/imperative";
-import { Readable } from "stream";
+import { Readable, Writable } from "stream";
 
 export class StreamUtils {
 
@@ -46,6 +46,47 @@ export class StreamUtils {
                     response.progress.endBar();
                     reject(error);
                 });
+            }).catch((streamRejection: any) => {
+                reject(streamRejection);
+            });
+        });
+    }
+
+    /**
+     * Pipes the readable stream to the writable stream.
+     *
+     * @param  stremPromise - promise that will resolve to a readable stream
+     * @param  writable - writable stream
+     * @param  response - response object from your handler, provide if
+     *                                         you want a progress bar created
+     * @returns  - promise that resolves when the h
+     */
+    public static async streamToStream(streamPromise: Promise<Readable>, writable: Writable, response?: IHandlerResponseApi): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            let downloadedBytes = 0;
+            const statusMessage = "Downloaded %d of ? bytes";
+            const task: ITaskWithStatus = {
+                statusMessage: "Starting transfer...",
+                percentComplete: 0,
+                stageName: TaskStage.IN_PROGRESS
+            };
+            if (response != null) {
+                response.progress.startBar({task});
+            }
+            streamPromise.then((stream) => {
+                stream.on("data", (chunk: Buffer) => {
+                    downloadedBytes += chunk.length;
+                    task.statusMessage = TextUtils.formatMessage(statusMessage, downloadedBytes);
+                });
+                stream.on("end", () => {
+                    response.progress.endBar();
+                    resolve("end");
+                });
+                stream.on("error", (error: any) => {
+                    response.progress.endBar();
+                    reject(error);
+                });
+                stream.pipe(writable);
             }).catch((streamRejection: any) => {
                 reject(streamRejection);
             });

--- a/src/cli/download/uss-file/UssFile.Handler.ts
+++ b/src/cli/download/uss-file/UssFile.Handler.ts
@@ -9,6 +9,8 @@
  *
  */
 
+import * as fs from "fs";
+
 import { IO } from "@brightside/imperative";
 import { StreamUtils } from "../../../api/StreamUtils";
 import { FTPBaseHandler } from "../../../FTPBase.Handler";
@@ -23,14 +25,12 @@ export default class DownloadUssFileHandler extends FTPBaseHandler {
         const file = params.arguments.file == null ?
             basename(ussFile) : // default the destination file name to the basename of the uss file e.g. /u/users/ibmuser/hello.txt -> hello.txt
             params.arguments.file;
-        let content: Buffer;
+        const writable = fs.createWriteStream(file);
         this.log.debug("Downloading USS file '%s' to local file '%s' in transfer mode '%s",
             ussFile, file, transferType);
         IO.createDirsSyncFromFilePath(file);
         const contentStreamPromise = params.connection.getDataset(ussFile, transferType, true);
-        content = await StreamUtils.streamToBuffer(contentStreamPromise, params.response);
-
-        IO.writeFile(file, content);
+        await StreamUtils.streamToStream(contentStreamPromise, writable, params.response);
 
         const successMsg = params.response.console.log("Successfully downloaded USS file '%s' to local file '%s'",
             ussFile, file);


### PR DESCRIPTION
`StreamUtils.streamToStream` is added to pipe the input stream to output stream. We may do the same thing to `ViewDataSetHandler` and `ViewUssFileHandler` later.