### PR TITLE
Allow to query others jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@brightside/imperative": "^2.0.0"
   },
   "dependencies": {
-    "zos-node-accessor": "1.0.1"
+    "zos-node-accessor": "1.0.2"
   },
   "devDependencies": {
     "@brightside/core": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zowe/zos-ftp",
-  "version": "0.0.1",
-  "description": "Data set, USS, and job functionality for CA Brightside via FTP",
+  "version": "0.1.0",
+  "description": "Data set, USS, and Jobs functionality via FTP for Zowe CLI",
   "main": "lib/index.js",
   "scripts": {
     "build": "npm run clean && npm run license && tsc --pretty && npm run lint && npm run checkTestsCompile",
@@ -20,7 +20,7 @@
     "configurationModule": "lib/imperative.js"
   },
   "publishConfig": {
-    "registry": "http://isl-dsdc.ca.com/artifactory/api/npm/npm-release-candidate"
+    "registry": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-local-release/"
   },
   "peerDependencies": {
     "@brightside/core": "^2.0.0",

--- a/src/api/JobUtils.ts
+++ b/src/api/JobUtils.ts
@@ -16,14 +16,14 @@ export class JobUtils {
     /**
      * Identify a job by job ID
      * Warning: slow since it lists all jobs
-     * @param  jobid - the job ID of the job you want to identify -
+     * @param  jobId - the job ID of the job you want to identify -
      *                         note: you can't use the abbreviated version like j123. it must be the full job ID
      * @param connection - connection to zos-node-accessor
      */
-    public static async findJobByID(jobid: string, connection: any) {
-        this.log.debug("Attempting to locate job by job ID %s", jobid);
-        jobid = jobid.toUpperCase();
-        const job = await connection.getJobStatus(jobid);
+    public static async findJobByID(jobId: string, connection: any) {
+        this.log.debug("Attempting to locate job by job ID %s", jobId);
+        jobId = jobId.toUpperCase();
+        const job = await connection.getJobStatus({jobId, owner: "*"});
         return job;
     }
 
@@ -32,7 +32,6 @@ export class JobUtils {
             jobs = jobs.slice(1);
         }
         return jobs.map((job: any) => {
-            const result: any = {};
             // object looks like:
             // JOBNAME, JOBID, OWNER, STATUS, CLASS
             // turn the object into a similar format to that returned by

--- a/src/api/StreamUtils.ts
+++ b/src/api/StreamUtils.ts
@@ -10,7 +10,7 @@
  */
 
 import { IHandlerResponseApi, ITaskWithStatus, TaskStage, TextUtils } from "@brightside/imperative";
-import { Readable } from "stream";
+import { Readable, Writable } from "stream";
 
 export class StreamUtils {
 
@@ -46,6 +46,47 @@ export class StreamUtils {
                     response.progress.endBar();
                     reject(error);
                 });
+            }).catch((streamRejection: any) => {
+                reject(streamRejection);
+            });
+        });
+    }
+
+    /**
+     * Pipes the readable stream to the writable stream.
+     *
+     * @param  stremPromise - promise that will resolve to a readable stream
+     * @param  writable - writable stream
+     * @param  response - response object from your handler, provide if
+     *                                         you want a progress bar created
+     * @returns  - promise that resolves when the h
+     */
+    public static async streamToStream(streamPromise: Promise<Readable>, writable: Writable, response?: IHandlerResponseApi): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            let downloadedBytes = 0;
+            const statusMessage = "Downloaded %d of ? bytes";
+            const task: ITaskWithStatus = {
+                statusMessage: "Starting transfer...",
+                percentComplete: 0,
+                stageName: TaskStage.IN_PROGRESS
+            };
+            if (response != null) {
+                response.progress.startBar({task});
+            }
+            streamPromise.then((stream) => {
+                stream.on("data", (chunk: Buffer) => {
+                    downloadedBytes += chunk.length;
+                    task.statusMessage = TextUtils.formatMessage(statusMessage, downloadedBytes);
+                });
+                stream.on("end", () => {
+                    response.progress.endBar();
+                    resolve("end");
+                });
+                stream.on("error", (error: any) => {
+                    response.progress.endBar();
+                    reject(error);
+                });
+                stream.pipe(writable);
             }).catch((streamRejection: any) => {
                 reject(streamRejection);
             });

--- a/src/cli/download/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
+++ b/src/cli/download/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
@@ -31,7 +31,13 @@ export default class ViewAllSpoolByJobIdHandler extends FTPBaseHandler {
         }
         for (const spoolFileToDownload of jobDetails.spoolFiles) {
             this.log.debug("Requesting spool files for job %s(%s) spool file ID %d", jobDetails.jobname, jobDetails.jobid, spoolFileToDownload.id);
-            const spoolFile = await params.connection.getJobLog(jobDetails.jobname, jobDetails.jobid, spoolFileToDownload.id);
+            const option = {
+                jobName: jobDetails.jobname,
+                jobId: jobDetails.jobid,
+                owner: "*",
+                fileId: spoolFileToDownload.id
+            };
+            const spoolFile = await params.connection.getJobLog(option);
             spoolFiles.push(spoolFile);
             spoolFileToDownload.contents = spoolFile;
             fullSpoolFiles.push(spoolFileToDownload);
@@ -50,7 +56,7 @@ export default class ViewAllSpoolByJobIdHandler extends FTPBaseHandler {
             const destinationFile = DownloadJobs.getSpoolDownloadFile(mockJobFile, params.arguments.omitJobidDirectory, params.arguments.directory);
             this.log.info("Downloading spool file %s to local file %s", spoolFileToDownload.ddname, destinationFile);
             IO.createDirsSyncFromFilePath(destinationFile);
-            const content = await params.connection.getJobLog(jobDetails.jobname, jobDetails.jobid, spoolFileToDownload.id);
+            const content = await params.connection.getJobLog(option);
             IO.writeFile(destinationFile, content);
         }
         const successMessage = params.response.console.log("Successfully downloaded %d spool files to %s", fullSpoolFiles.length, destination);

--- a/src/cli/download/uss-file/UssFile.Handler.ts
+++ b/src/cli/download/uss-file/UssFile.Handler.ts
@@ -9,6 +9,8 @@
  *
  */
 
+import * as fs from "fs";
+
 import { IO } from "@brightside/imperative";
 import { StreamUtils } from "../../../api/StreamUtils";
 import { FTPBaseHandler } from "../../../FTPBase.Handler";
@@ -23,14 +25,12 @@ export default class DownloadUssFileHandler extends FTPBaseHandler {
         const file = params.arguments.file == null ?
             basename(ussFile) : // default the destination file name to the basename of the uss file e.g. /u/users/ibmuser/hello.txt -> hello.txt
             params.arguments.file;
-        let content: Buffer;
+        const writable = fs.createWriteStream(file);
         this.log.debug("Downloading USS file '%s' to local file '%s' in transfer mode '%s",
             ussFile, file, transferType);
         IO.createDirsSyncFromFilePath(file);
         const contentStreamPromise = params.connection.getDataset(ussFile, transferType, true);
-        content = await StreamUtils.streamToBuffer(contentStreamPromise, params.response);
-
-        IO.writeFile(file, content);
+        await StreamUtils.streamToStream(contentStreamPromise, writable, params.response);
 
         const successMsg = params.response.console.log("Successfully downloaded USS file '%s' to local file '%s'",
             ussFile, file);

--- a/src/cli/list/jobs/Jobs.Handler.ts
+++ b/src/cli/list/jobs/Jobs.Handler.ts
@@ -16,8 +16,16 @@ import { IFTPHandlerParams } from "../../../IFTPHandlerParams";
 export default class ListJobsHandler extends FTPBaseHandler {
     public async processFTP(params: IFTPHandlerParams): Promise<void> {
         let jobs: string[];
-        this.log.debug("Listing jobs that match prefix %s", params.arguments.prefix);
-        jobs = await params.connection.listJobs(params.arguments.prefix);
+        const option: any = {
+            jobName: params.arguments.prefix,
+        };
+        let debugMessage = `Listing jobs that match prefix ${params.arguments.prefix}`;
+        if (params.arguments.owner) {
+            option.owner = params.arguments.owner;
+            debugMessage += ` and are owned by ${option.owner}`;
+        }
+        this.log.debug(debugMessage);
+        jobs = await params.connection.listJobs(option);
         this.log.debug("List returned %d jobs", jobs.length);
         const filteredJobs = JobUtils.parseJobDetails(jobs);
         params.response.data.setObj(filteredJobs);

--- a/src/cli/list/jobs/Jobs.definition.ts
+++ b/src/cli/list/jobs/Jobs.definition.ts
@@ -31,12 +31,13 @@ export const ListJobsDefinition: ICommandDefinition = {
     options: [{
         name: "prefix", aliases: ["p"],
         description: "Specify the job name prefix of the jobs you own and want to list. " +
-        "You can specify a wildcard, which is usually in the form \"JOB*\".\n ",
+        "You can specify a wildcard, which is usually in the form \"JOB*\". \n ",
         type: "string",
         required: true
     }, {
         name: "owner", aliases: ["o"],
-        description: "Specify the owner user ID of the jobs you want to list.",
+        description: "Specify the owner user ID of the jobs you want to list. The owner " +
+        "is the individual/user who submitted the job OR the user ID assigned to the job. \n ",
         type: "string",
         required: false
     }],

--- a/src/cli/list/jobs/Jobs.definition.ts
+++ b/src/cli/list/jobs/Jobs.definition.ts
@@ -23,16 +23,22 @@ export const ListJobsDefinition: ICommandDefinition = {
             description: "List all jobs with names beginning beginning with \"ibmu\"",
             options: "--prefix \"ibmu*\""
         },
+        {
+            description: "List Alice's jobs with names beginning beginning with \"ibmu\"",
+            options: "--prefix \"ibmu*\" --owner \"alice\""
+        },
     ],
     options: [{
         name: "prefix", aliases: ["p"],
-        description: "Specify the job name prefix of the jobs you want to list. " +
-        "The command does not prevalidate the owner. " +
-        "You can specify a wildcard according to the z/OSMF Jobs REST endpoint documentation, " +
-        "which is usually in the form \"JOB*\".\n When using FTP, prefix is required. You " +
-        "cannot search by owner except by filtering yourself.",
+        description: "Specify the job name prefix of the jobs you own and want to list. " +
+        "You can specify a wildcard, which is usually in the form \"JOB*\".\n ",
         type: "string",
         required: true
+    }, {
+        name: "owner", aliases: ["o"],
+        description: "Specify the owner user ID of the jobs you want to list.",
+        type: "string",
+        required: false
     }],
     profile:
         {optional: ["zftp"]},

--- a/src/cli/rename/uss-file/UssFile.definition.ts
+++ b/src/cli/rename/uss-file/UssFile.definition.ts
@@ -21,7 +21,7 @@ export const RenameUssFileDefinition: ICommandDefinition = {
     examples: [
         {
             description: "Rename the file /u/users/ibmuser/hello.txt to /u/users/ibmuser/hello2.txt",
-            options: "\"/u/users/ibmuser/hello.txt)\" \"/u/users/ibmuser/hello2.txt\""
+            options: "\"/u/users/ibmuser/hello.txt\" \"/u/users/ibmuser/hello2.txt\""
         }
     ],
     positionals: [

--- a/src/cli/view/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
+++ b/src/cli/view/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
@@ -29,7 +29,13 @@ export default class ViewAllSpoolByJobIdHandler extends FTPBaseHandler {
         }
         for (const spoolFileToDownload of jobDetails.spoolFiles) {
             this.log.debug("Requesting spool files for job %s(%s) spool file ID %d", jobDetails.jobname, jobDetails.jobid, spoolFileToDownload.id);
-            const spoolFile = await params.connection.getJobLog(jobDetails.jobname, jobDetails.jobid, spoolFileToDownload.id);
+            const option = {
+                jobName: jobDetails.jobname,
+                jobId: jobDetails.jobid,
+                owner: "*",
+                fileId: spoolFileToDownload.id
+            };
+            const spoolFile = await params.connection.getJobLog(option);
             spoolFiles.push(spoolFile);
             spoolFileToDownload.contents = spoolFile;
             fullSpoolFiles.push(spoolFileToDownload);

--- a/src/cli/view/spool-file-by-id/SpoolFileById.Handler.ts
+++ b/src/cli/view/spool-file-by-id/SpoolFileById.Handler.ts
@@ -20,7 +20,14 @@ export default class SpoolFileByIdHandler extends FTPBaseHandler {
     public async processFTP(params: IFTPHandlerParams): Promise<void> {
         this.log.debug("Getting spool file with id %s for job with ID %s", params.arguments.spoolfileid, params.arguments.jobid);
         // Get the content, set the JSON response object, and print
-        const content: string = await params.connection.getJobLog(undefined, params.arguments.jobid, params.arguments.spoolfileid);
+        const option = {
+            jobName: "*",
+            jobId: params.arguments.jobid,
+            owner: "*",
+            fileId: params.arguments.spoolfileid
+        };
+
+        const content: string = await params.connection.getJobLog(option);
         params.response.data.setObj(content);
         const successMessage = this.log.info(`Spool file "${params.arguments.spoolfileid}" content obtained for job ID "${params.arguments.jobid})"`);
         params.response.data.setMessage(successMessage);


### PR DESCRIPTION
The option --owner is added to query the status of the job owned by others, which depends on the new update in zos-node-accessor 1.0.2.