### PR TITLE
Streaming fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ package-lock.json
 
 node-report*
 /docs/typedoc/
+
+*.tgz
+ds1
+ussFile1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zos-ftp-for-zowe-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Data set, USS, and Jobs functionality via FTP for Zowe CLI",
   "main": "lib/index.js",
   "scripts": {

--- a/src/api/CreateDataset.ts
+++ b/src/api/CreateDataset.ts
@@ -132,18 +132,19 @@ export class CreateDataset extends AbstractTemplatedJCL {
         const continueLine = "//   ";
 
         // todo: make sure all options are used here
+        if (options.alcunit) {
+            let spaceParams = "SPACE=(";
+            spaceParams += options.alcunit.toUpperCase() + ",(";
+            spaceParams += options.primary;
+            if (options.secondary != null) {
+                spaceParams += "," + options.secondary;
+            }
+            spaceParams += "))";
 
-        let spaceParams = "SPACE=(";
-        spaceParams += options.alcunit.toUpperCase() + ",(";
-        spaceParams += options.primary;
-        if (options.secondary != null) {
-            spaceParams += "," + options.secondary;
-        }
-        spaceParams += "))";
-
-        createDDValues.push(spaceParams);
-        if (options.volser != null) {
-            createDDValues.push("VOLSER=" + options.volser.toUpperCase());
+            createDDValues.push(spaceParams);
+            if (options.volser != null) {
+                createDDValues.push("VOLSER=" + options.volser.toUpperCase());
+            }
         }
         if (options.lrecl != null) {
             createDDValues.push("LRECL=" + options.lrecl);

--- a/src/api/StreamUtils.ts
+++ b/src/api/StreamUtils.ts
@@ -41,11 +41,15 @@ export class StreamUtils {
                     task.statusMessage = TextUtils.formatMessage(statusMessage, data.length, estimatedSize);
                 });
                 stream.on("end", () => {
-                    response.progress.endBar();
+                    if (response != null) {
+                        response.progress.endBar();
+                    }
                     resolve(data);
                 });
                 stream.on("error", (error: any) => {
-                    response.progress.endBar();
+                    if (response != null) {
+                        response.progress.endBar();
+                    }
                     reject(error);
                 });
             }).catch((streamRejection: any) => {
@@ -87,11 +91,15 @@ export class StreamUtils {
                     task.statusMessage = TextUtils.formatMessage(statusMessage, downloadedBytes, estimatedSize);
                 });
                 stream.on("end", () => {
-                    response.progress.endBar();
+                    if (response != null) {
+                        response.progress.endBar();
+                    }
                     resolve("end");
                 });
                 stream.on("error", (error: any) => {
-                    response.progress.endBar();
+                    if (response != null) {
+                        response.progress.endBar();
+                    }
                     reject(error);
                 });
             }).catch((streamRejection: any) => {

--- a/src/cli/download/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
+++ b/src/cli/download/all-spool-by-jobid/AllSpoolByJobId.Handler.ts
@@ -45,9 +45,11 @@ export default class ViewAllSpoolByJobIdHandler extends FTPBaseHandler {
                 "jobid": jobDetails.jobid, "jobname": jobDetails.jobname,
                 "recfm": "FB", "lrecl": 80, "byte-count": spoolFileToDownload.byteCount,
                 // todo is recfm or lrecl available? FB 80 could be wrong
-                "record-count": 0, "job-correlator": undefined, // most of these options don't matter for download
+                "record-count": 0,
+                "job-correlator": "", // most of these options don't matter for download
                 "class": "A", "ddname": spoolFileToDownload.ddname,
-                "id": spoolFileToDownload.id, "records-url": undefined,
+                "id": spoolFileToDownload.id,
+                "records-url": "",
                 "subsystem": "JES2",
                 "stepname": spoolFileToDownload.stepname,
                 "procstep": spoolFileToDownload.procstep === "N/A" || spoolFileToDownload.procstep == null ?


### PR DESCRIPTION
Proposed fixed for Issue #26 to make streaming work without a response object.
Propose to bump version number of plugin.

Tried adding the `"strictNullChecks": true` to `tsconfig.json` but it will require more fixes in the tests where there are many cases assigning null and undefined to strings as well as missing undefined checks or `!`. 