### PR TITLE
Update zos-node-accessor to 1.0.5 and call stream.resume() for Node.JS v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@brightside/imperative": "^2.0.0"
   },
   "dependencies": {
-    "zos-node-accessor": "~1.0.4"
+    "zos-node-accessor": "1.0.5"
   },
   "devDependencies": {
     "@brightside/core": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zos-ftp-for-zowe-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Data set, USS, and Jobs functionality via FTP for Zowe CLI",
   "main": "lib/index.js",
   "scripts": {

--- a/src/api/StreamUtils.ts
+++ b/src/api/StreamUtils.ts
@@ -52,6 +52,7 @@ export class StreamUtils {
                     }
                     reject(error);
                 });
+                stream.resume();
             }).catch((streamRejection: any) => {
                 reject(streamRejection);
             });


### PR DESCRIPTION
Fix #32 

Signed-off-by: Qi Liang <liangqi@cn.ibm.com>

