### PR TITLE
Method for Zowe Explorer Extension for FTP to consume

### DIFF
--- a/src/api/CoreUtils.ts
+++ b/src/api/CoreUtils.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { IImperativeError, Logger } from "@zowe/imperative";
+import { ICommandProfileTypeConfiguration, IImperativeError, Logger } from "@zowe/imperative";
 import { isNullOrUndefined } from "util";
 
 /**
@@ -88,6 +88,11 @@ export class CoreUtils {
             result[key.toLowerCase()] = obj[key];
         }
         return result;
+    }
+
+    public static async getProfileMeta(): Promise<ICommandProfileTypeConfiguration[]> {
+        const ftpProfile = require("../imperative").profiles as ICommandProfileTypeConfiguration[];
+        return ftpProfile;
     }
 
     protected static get log(): Logger {

--- a/src/api/CoreUtils.ts
+++ b/src/api/CoreUtils.ts
@@ -91,7 +91,7 @@ export class CoreUtils {
     }
 
     public static async getProfileMeta(): Promise<ICommandProfileTypeConfiguration[]> {
-        const ftpProfile = require("../imperative").profiles as ICommandProfileTypeConfiguration[];
+        const ftpProfile = await require("../imperative").profiles as ICommandProfileTypeConfiguration[];
         return ftpProfile;
     }
 


### PR DESCRIPTION
Zowe Explorer Extension for FTP would like to create a zfpt profiles folder within the .zowe home directory without having zowe-cli-ftp-plugin as a prerequisite.  This new method will allow this to happen.

Gif below show this import on the FTP vsc ext and some extender API initialization work I have done but isn't available yet and waiting on this change to become available for import
![ZE-zFTP-initialize](https://user-images.githubusercontent.com/49491949/115922731-401bd380-a44b-11eb-9212-031bac00323d.gif)
