### PR TITLE
Throw error when list jobs with invalid prefix or owner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the z/OS FTP Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+- Throw error when list jobs with invalid prefix or owner.
 ## `2.1.0`
 
 - Add encoding setting in profile.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "EPL-2.0",
       "dependencies": {
-        "zos-node-accessor": "1.0.12"
+        "zos-node-accessor": "1.0.13"
       },
       "devDependencies": {
         "@types/fs-extra": "^5.0.5",
@@ -13392,9 +13392,9 @@
       }
     },
     "node_modules/zos-node-accessor": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/zos-node-accessor/-/zos-node-accessor-1.0.12.tgz",
-      "integrity": "sha512-WA4DVgYLMDIYFh5eTvY9zQSgO6MJvClvFX2RMU5NCLbrTDVVoQ8e0tsUsHU2M0X7P7cY28Lrk1nDZSbdQf0imw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/zos-node-accessor/-/zos-node-accessor-1.0.13.tgz",
+      "integrity": "sha512-BX/ANK2ckSf+Dg5kkz/kd2UDx33fg+JJWoySDOxVF1TyuQDRZz9VfLRsYEi3JGxgv78T6KFFviodbDWNfMFOQA==",
       "dependencies": {
         "debug": "~2.6.8",
         "ftp4": "~0.3.13",
@@ -23491,9 +23491,9 @@
       "dev": true
     },
     "zos-node-accessor": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/zos-node-accessor/-/zos-node-accessor-1.0.12.tgz",
-      "integrity": "sha512-WA4DVgYLMDIYFh5eTvY9zQSgO6MJvClvFX2RMU5NCLbrTDVVoQ8e0tsUsHU2M0X7P7cY28Lrk1nDZSbdQf0imw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/zos-node-accessor/-/zos-node-accessor-1.0.13.tgz",
+      "integrity": "sha512-BX/ANK2ckSf+Dg5kkz/kd2UDx33fg+JJWoySDOxVF1TyuQDRZz9VfLRsYEi3JGxgv78T6KFFviodbDWNfMFOQA==",
       "requires": {
         "debug": "~2.6.8",
         "ftp4": "~0.3.13",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@zowe/imperative": "^5.0.0"
   },
   "dependencies": {
-    "zos-node-accessor": "1.0.12"
+    "zos-node-accessor": "1.0.13"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.5",


### PR DESCRIPTION
Signed-off-by: Tina <tiantn@cn.ibm.com>

Upgrade zos-node-accessor to 1.0.13.