### PR TITLE
fix to disallow invalid characters in filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the z/OS FTP Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+- BugFix: Provide new utility function that checks file names for valid characters [143](https://github.com/zowe/zowe-cli-ftp-plugin/issues/143).
+
 ## `2.1.3`
 
 - Update example of `upload file-to-data-set` command.

--- a/src/cli/Utilities.ts
+++ b/src/cli/Utilities.ts
@@ -1,0 +1,51 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export class Utilities{
+    /**
+     * Check to ensure filename only contains valid characters
+     * @param {fileName} string - filename to be evaluated
+     * @returns {Promise<boolean>} - promise that resolves to true if filename contains valid characters
+     * @memberof Utilities
+     */
+    public static async isValidFileName(fileName: string): Promise<boolean> {
+        //to prevent magic number eslint errors
+        //(valid characters deduced from https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
+        const iso8859_1_start_first = 32; // first valid code point for first chunk of valid characters in the ISO/IEC 8859-1 table
+        const iso8859_1_end_first = 127;
+        const iso8859_1_start_second = 160; //second chunk of valid characters
+        const iso8859_1_end_second = 255;
+        const binary = 2;
+        const hexadecimal = 16;
+
+        const unicodeString = fileName.split('').map(char => `U+${char.charCodeAt(0).toString(hexadecimal).toUpperCase()}`).join(' ');
+        const codePoints = unicodeString.split(' ');
+        for (const codePoint of codePoints) {
+            // Extract the decimal representation from the code point (e.g., ☻ = U+263B => 9787)
+            const decimalRepresentation = parseInt(codePoint.substring(binary), hexadecimal);
+
+            // Check if the code point is in the range of valid characters
+            const validRanges = [
+                { start: iso8859_1_start_first, end: iso8859_1_end_first },
+                { start: iso8859_1_start_second, end: iso8859_1_end_second }
+            ];
+
+            const isValidCharacter = validRanges.some(range => {
+                return decimalRepresentation >= range.start && decimalRepresentation <= range.end;
+            });
+
+            if (!isValidCharacter) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/cli/Utilities.ts
+++ b/src/cli/Utilities.ts
@@ -17,35 +17,20 @@ export class Utilities{
      * @memberof Utilities
      */
     public static async isValidFileName(fileName: string): Promise<boolean> {
-        //to prevent magic number eslint errors
-        //(valid characters deduced from https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
-        const iso8859_1_start_first = 32; // first valid code point for first chunk of valid characters in the ISO/IEC 8859-1 table
-        const iso8859_1_end_first = 127;
-        const iso8859_1_start_second = 160; //second chunk of valid characters
-        const iso8859_1_end_second = 255;
-        const binary = 2;
-        const hexadecimal = 16;
+        // Define valid character ranges for ISO/IEC 8859-1 https://en.wikipedia.org/wiki/ISO/IEC_8859-1
+        const validRanges = [
+            { start: 32, end: 127 },   // First chunk of valid characters
+            { start: 160, end: 255 }  // Second chunk of valid characters
+        ];
 
-        const unicodeString = fileName.split('').map(char => `U+${char.charCodeAt(0).toString(hexadecimal).toUpperCase()}`).join(' ');
-        const codePoints = unicodeString.split(' ');
-        for (const codePoint of codePoints) {
-            // Extract the decimal representation from the code point (e.g., ☻ = U+263B => 9787)
-            const decimalRepresentation = parseInt(codePoint.substring(binary), hexadecimal);
-
-            // Check if the code point is in the range of valid characters
-            const validRanges = [
-                { start: iso8859_1_start_first, end: iso8859_1_end_first },
-                { start: iso8859_1_start_second, end: iso8859_1_end_second }
-            ];
-
-            const isValidCharacter = validRanges.some(range => {
-                return decimalRepresentation >= range.start && decimalRepresentation <= range.end;
-            });
-
-            if (!isValidCharacter) {
+        // Check if each character in the filename is within a valid range
+        for (const char of fileName) {
+            const charCode = char.charCodeAt(0);
+            if (!validRanges.some(range => charCode >= range.start && charCode <= range.end)) {
                 return false;
             }
         }
+
         return true;
     }
 }

--- a/src/cli/Utilities.ts
+++ b/src/cli/Utilities.ts
@@ -16,7 +16,7 @@ export class Utilities{
      * @returns {Promise<boolean>} - promise that resolves to true if filename contains valid characters
      * @memberof Utilities
      */
-    public static async isValidFileName(fileName: string): Promise<boolean> {
+    public static isValidFileName(fileName: string): boolean {
         // Define valid character ranges for ISO/IEC 8859-1 https://en.wikipedia.org/wiki/ISO/IEC_8859-1
         const validRanges = [
             { start: 32, end: 127 },   // First chunk of valid characters

--- a/src/cli/download/data-set/DataSet.Handler.ts
+++ b/src/cli/download/data-set/DataSet.Handler.ts
@@ -14,13 +14,45 @@ import { FTPBaseHandler } from "../../../FTPBase.Handler";
 import { IFTPHandlerParams } from "../../../IFTPHandlerParams";
 import { FTPProgressHandler } from "../../../FTPProgressHandler";
 import { DataSetUtils, TRANSFER_TYPE_ASCII, TRANSFER_TYPE_ASCII_RDW, TRANSFER_TYPE_BINARY, TRANSFER_TYPE_BINARY_RDW } from "../../../api";
+import { ImperativeError } from "@zowe/imperative";
 
+function isValidFileName(fileName: string) {
+    //to prevent magic number eslint errors
+    const iso8859_1_start_first = 32; // first valid code point for first chunk of valid characters in the ISO/IEC 8859-1 table
+    const iso8859_1_end_first = 127;
+    const iso8859_1_start_second = 160; //second chunk of valid characters
+    const iso8859_1_end_second = 255;
+    const binary = 2;
+    const hexadecimal = 16;
+
+    const unicodeString = fileName.split('').map(char => `U+${char.charCodeAt(0).toString(hexadecimal).toUpperCase()}`).join(' ');
+    const codePoints = unicodeString.split(' ');
+
+    for (const codePoint of codePoints) {
+        // Extract the decimal representation from the code point (e.g., ☻ = U+263B => 9787)
+        const decimalRepresentation = parseInt(codePoint.substring(binary), hexadecimal);
+
+        // Check if the code point is in the range of valid characters (valid numbers deduced from https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
+        if ((decimalRepresentation >= iso8859_1_start_first && decimalRepresentation <= iso8859_1_end_first) ||
+            (decimalRepresentation >= iso8859_1_start_second && decimalRepresentation <= iso8859_1_end_second))
+        {
+            // If any invalid code point is found, return false
+            return false;
+        }
+    }
+    return true;
+}
 export default class DownloadDataSetHandler extends FTPBaseHandler {
     public async processFTP(params: IFTPHandlerParams): Promise<void> {
 
         const file = params.arguments.file == null ?
             ZosFilesUtils.getDirsFromDataSet(params.arguments.dataSet) :
             params.arguments.file;
+
+        // Validate the file name before proceeding
+        if (!isValidFileName(file)) {
+            throw new ImperativeError({msg: "Invalid file name. Please check the file name for typos."});
+        }
 
         let progress;
         if (params.response && params.response.progress) {

--- a/src/cli/download/data-set/DataSet.Handler.ts
+++ b/src/cli/download/data-set/DataSet.Handler.ts
@@ -18,6 +18,7 @@ import { ImperativeError } from "@zowe/imperative";
 
 function isValidFileName(fileName: string) {
     //to prevent magic number eslint errors
+    //(valid characters deduced from https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
     const iso8859_1_start_first = 32; // first valid code point for first chunk of valid characters in the ISO/IEC 8859-1 table
     const iso8859_1_end_first = 127;
     const iso8859_1_start_second = 160; //second chunk of valid characters
@@ -32,11 +33,17 @@ function isValidFileName(fileName: string) {
         // Extract the decimal representation from the code point (e.g., ☻ = U+263B => 9787)
         const decimalRepresentation = parseInt(codePoint.substring(binary), hexadecimal);
 
-        // Check if the code point is in the range of valid characters (valid numbers deduced from https://en.wikipedia.org/wiki/ISO/IEC_8859-1)
-        if ((decimalRepresentation >= iso8859_1_start_first && decimalRepresentation <= iso8859_1_end_first) ||
-            (decimalRepresentation >= iso8859_1_start_second && decimalRepresentation <= iso8859_1_end_second))
-        {
-            // If any invalid code point is found, return false
+        // Check if the code point is in the range of valid characters
+        const validRanges = [
+            { start: iso8859_1_start_first, end: iso8859_1_end_first },
+            { start: iso8859_1_start_second, end: iso8859_1_end_second }
+        ];
+
+        const isValidCharacter = validRanges.some(range => {
+            return decimalRepresentation >= range.start && decimalRepresentation <= range.end;
+        });
+
+        if (!isValidCharacter) {
             return false;
         }
     }

--- a/src/cli/download/data-set/DataSet.Handler.ts
+++ b/src/cli/download/data-set/DataSet.Handler.ts
@@ -20,8 +20,8 @@ import { Utilities } from "../../Utilities";
 export default class DownloadDataSetHandler extends FTPBaseHandler {
     public async processFTP(params: IFTPHandlerParams): Promise<void> {
         const file = params.arguments.file == null ?
-        ZosFilesUtils.getDirsFromDataSet(params.arguments.dataSet) :
-        params.arguments.file;
+            ZosFilesUtils.getDirsFromDataSet(params.arguments.dataSet) :
+            params.arguments.file;
         try {
             // Validate the destination file name before proceeding
             if (!(await Utilities.isValidFileName(file))) {

--- a/src/cli/download/data-set/DataSet.Handler.ts
+++ b/src/cli/download/data-set/DataSet.Handler.ts
@@ -24,7 +24,7 @@ export default class DownloadDataSetHandler extends FTPBaseHandler {
             params.arguments.file;
         try {
             // Validate the destination file name before proceeding
-            if (!(await Utilities.isValidFileName(file))) {
+            if (!(Utilities.isValidFileName(file))) {
                 throw new ImperativeError({ msg: ZosFilesMessages.invalidFileName.message });
             }
 

--- a/src/cli/download/data-set/DataSet.Handler.ts
+++ b/src/cli/download/data-set/DataSet.Handler.ts
@@ -25,7 +25,7 @@ export default class DownloadDataSetHandler extends FTPBaseHandler {
         try {
             // Validate the destination file name before proceeding
             if (!(await Utilities.isValidFileName(file))) {
-                throw new ImperativeError({ msg: "Invalid file name. Please check the file name for typos." });
+                throw new ImperativeError({ msg: ZosFilesMessages.invalidFileName.message });
             }
 
             let progress;
@@ -54,7 +54,7 @@ export default class DownloadDataSetHandler extends FTPBaseHandler {
                 throw e;
             }
             throw new ImperativeError({
-                msg: `An error was encountered while trying to download your dataset '${file}'.\nError details: ${e.message}`
+                msg: `An error was encountered while trying to download your file '${file}'.\nError details: ${e.message}`
             });
         }
     }


### PR DESCRIPTION
**What It Does**
Provides a fix for [issue143](https://github.com/zowe/zowe-cli-ftp-plugin/issues/143) by throwing an error when using invalid filenames so the progress bar doesn't loop indefinitely from the unhandled case of emojis and other invalid characters in dataset names. Depends on [zowe-cli PR 1831](https://github.com/zowe/zowe-cli/pull/1831) - **unit tests will fail until this PR is merged in**.


**How to Test**
Tested with the following `launch.json` configurations

> ```
> 
>     {
>         "type": "node",
>         "request": "launch",
>         "name": "ftp download ds",
>         "program": "${workspaceFolder}/packages/cli/lib/main.js",
>         "console": "integratedTerminal",
>         "args": ["zos-ftp", "download", "data-set", <realTestingDataSetName>, "-f", "testing.txt^B", "--secure-ftp", "false"],
>         "outputCapture": "std",
>         "resolveSourceMapLocations": null
>     }
> ```
> Expected response: ```Data set downloaded successfully. testing.txt^B```
<br>

> ```
>         "args": ["zos-ftp", "download", "data-set", <realTestingDataSetName>, "-f", "testing.txt☻", "--secure-ftp", "false"],
> ```
> Expected response: ```Command Error: Invalid file name. Please check the file name for typos.```
<br>

> ```
>         "args": ["zos-ftp", "download", "data-set", <realTestingDataSetName>, "-f", "testing.txt", "--secure-ftp", "false"],
> ```
> Expected response: ```Data set downloaded successfully. testing.txt```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)