### PR TITLE
[Innovation] Add ARM64 MacOS runner

### DIFF
--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -1,6 +1,17 @@
 name: zowe-cli-plugin
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      macos-type:
+        type: choice
+        description: Run against x86-based MacOS (12), otherwise run against ARM64-based MacOS (14)
+        default: macos-14
+        options:
+          - macos-12
+          - macos-14
 
 jobs:
   test:
@@ -12,7 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]
-        os: [windows-latest, ubuntu-latest, macos-latest, macos-14]
+        os: 
+          - windows-latest
+          - ubuntu-latest
+          - ${{ github.event.inputs.macos-type || 'macos-14'}}
     env:
       OS: ${{ matrix.os }}
       NODE: ${{ matrix.node-version }}

--- a/.github/workflows/zowe-cli-plugin.yml
+++ b/.github/workflows/zowe-cli-plugin.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-14]
     env:
       OS: ${{ matrix.os }}
       NODE: ${{ matrix.node-version }}


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds `macos-14` to the test strategy, validating the CLI and Daemon function as expected on ARM64.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->