### PR TITLE
Fix jest-stare output missing for system tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     },
     "reporters": [
       "default",
+      "jest-stare",
       [
         "jest-junit",
         {
@@ -111,7 +112,7 @@
       [
         "jest-html-reporter",
         {
-          "pageTitle": "DB2 Plugin Test Results",
+          "pageTitle": "FTP Plugin Test Results",
           "outputPath": "__tests__/__results__/results.html",
           "includeFailureMsg": true
         }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Follow up to #174 that fixes the `__tests__/__results__/system/jest-stare` folder not being created.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->