### PR TITLE
ci(v3): Fix GH project status for pull requests

### DIFF
--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -31,6 +31,6 @@ jobs:
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true
-        item-status: ${{ github.event.action == 'ready_for_review' && env.PR_STATUS_READY || env.PR_STATUS_DRAFT }}
+        item-status: ${{ github.event.pull_request.draft && env.PR_STATUS_DRAFT || env.PR_STATUS_READY }}
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}


### PR DESCRIPTION
Fixes non-draft PRs being categorized as In Progress rather than Ready for Review